### PR TITLE
Dynamo Query API: Support KeyConditionExpression

### DIFF
--- a/sgv2-dynamo-api/pom.xml
+++ b/sgv2-dynamo-api/pom.xml
@@ -12,7 +12,7 @@
   <properties>
     <airline.version>2.8.2</airline.version>
     <swagger-ui.version>3.35.0</swagger-ui.version>
-    <dynamodb.sdk.version>1.11.477</dynamodb.sdk.version>
+    <dynamodb.sdk.version>1.12.190</dynamodb.sdk.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/sgv2-dynamo-api/src/main/java/io/stargate/sgv2/dynamosvc/dynamo/ItemProxy.java
+++ b/sgv2-dynamo-api/src/main/java/io/stargate/sgv2/dynamosvc/dynamo/ItemProxy.java
@@ -53,7 +53,7 @@ public class ItemProxy extends Proxy {
     Schema.CqlTable table =
         bridge
             .getTable(KEYSPACE_NAME, tableName)
-            .orElseThrow(() -> new IllegalArgumentException("Table not found"));
+            .orElseThrow(() -> new IllegalArgumentException("Table not found: " + tableName));
     Map<String, QueryOuterClass.ColumnSpec> columnMap =
         table.getColumnsList().stream()
             .collect(Collectors.toMap(QueryOuterClass.ColumnSpec::getName, Function.identity()));

--- a/sgv2-dynamo-api/src/main/java/io/stargate/sgv2/dynamosvc/dynamo/Proxy.java
+++ b/sgv2-dynamo-api/src/main/java/io/stargate/sgv2/dynamosvc/dynamo/Proxy.java
@@ -3,6 +3,7 @@ package io.stargate.sgv2.dynamosvc.dynamo;
 import static com.amazonaws.services.dynamodbv2.model.KeyType.HASH;
 import static com.amazonaws.services.dynamodbv2.model.KeyType.RANGE;
 
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import com.amazonaws.services.dynamodbv2.model.KeySchemaElement;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.DeserializationFeature;
@@ -70,5 +71,14 @@ public abstract class Proxy {
       resultRows.add(converter.mapFromProtoValues(row.getValuesList()));
     }
     return resultRows;
+  }
+
+  protected AttributeValue getExpressionAttributeValue(
+      Map<String, AttributeValue> map, String key) {
+    AttributeValue value = map.get(key);
+    if (value == null) {
+      throw new IllegalArgumentException(key + " does not appear in expression attributes");
+    }
+    return value;
   }
 }

--- a/sgv2-dynamo-api/src/main/java/io/stargate/sgv2/dynamosvc/dynamo/QueryProxy.java
+++ b/sgv2-dynamo-api/src/main/java/io/stargate/sgv2/dynamosvc/dynamo/QueryProxy.java
@@ -1,0 +1,271 @@
+package io.stargate.sgv2.dynamosvc.dynamo;
+
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import com.amazonaws.services.dynamodbv2.model.QueryRequest;
+import com.amazonaws.services.dynamodbv2.model.QueryResult;
+import io.stargate.proto.QueryOuterClass;
+import io.stargate.proto.Schema;
+import io.stargate.sgv2.common.cql.builder.Predicate;
+import io.stargate.sgv2.common.cql.builder.QueryBuilder;
+import io.stargate.sgv2.common.grpc.StargateBridgeClient;
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class QueryProxy extends Proxy {
+
+  private static final Logger logger = LoggerFactory.getLogger(QueryProxy.class);
+
+  private static final Map<String, Predicate> operatorConverter =
+      new HashMap<String, Predicate>() {
+        {
+          put("=", Predicate.EQ);
+          put("<=", Predicate.LTE);
+          put("<", Predicate.LT);
+          put(">=", Predicate.GTE);
+          put(">", Predicate.GT);
+        }
+      };
+
+  /**
+   * Basic partition key equality pattern
+   *
+   * <p>Example:<br>
+   * partitionKeyName = :partitionkeyval
+   */
+  private static final Pattern EQUALITY_PATTERN =
+      Pattern.compile("^\\s*(\\S+)\\s*=\\s*(:\\S+)\\s*$");
+
+  /**
+   * Basic partition key equality pattern + Sort key operation comparison pattern
+   *
+   * <p>Examples:<br>
+   * partitionKeyName = :partitionkeyval AND sortKeyName = :sortkeyval<br>
+   * partitionKeyName = :partitionkeyval AND sortKeyName < :sortkeyval<br>
+   * partitionKeyName = :partitionkeyval AND sortKeyName <= :sortkeyval<br>
+   * partitionKeyName = :partitionkeyval AND sortKeyName > :sortkeyval<br>
+   * partitionKeyName = :partitionkeyval AND sortKeyName >= :sortkeyval<br>
+   */
+  private static final Pattern OP_COMPARISON_PATTERN =
+      Pattern.compile("(?i)(\\S+)\\s*=\\s*(:\\S+)\\s*AND\\s*(\\S+)\\s*([<>=]+)\\s*(:\\S+)");
+
+  /**
+   * Basic partition key equality pattern + Sort key interval comparison pattern
+   *
+   * <p>Example:<br>
+   * partitionKeyName = :partitionkeyval AND sortKeyName BETWEEN :sortkeyval1 AND :sortkeyval2
+   */
+  private static final Pattern BETWEEN_PATTERN =
+      Pattern.compile(
+          "(?i)(\\S+)\\s*=\\s*(:\\S+)\\s*AND\\s*(\\S+)\\s*BETWEEN\\s*(:\\S+)\\s*AND\\s*(:\\S+)");
+
+  /**
+   * Basic partition key equality pattern + Sort key begins_with pattern (cannot use with number)
+   *
+   * <p>Example:<br>
+   * partitionKeyName = :partitionkeyval AND begins_with ( sortKeyName, :sortkeyval )
+   */
+  private static final Pattern BEGIN_WITH_PATTERN =
+      Pattern.compile(
+          "(?i)(\\S+)\\s*=\\s*(:\\S+)\\s*AND\\s*begins_with\\s*\\(\\s*(\\S+),\\s*(:\\S+)\\s*\\)");
+
+  public QueryResult query(QueryRequest queryRequest, StargateBridgeClient bridge) {
+    // Get table schema
+    final String tableName = queryRequest.getTableName();
+    Schema.CqlTable table =
+        bridge
+            .getTable(KEYSPACE_NAME, tableName)
+            .orElseThrow(() -> new IllegalArgumentException("Table not found: " + tableName));
+    QueryOuterClass.ColumnSpec partitionKey = table.getPartitionKeyColumns(0);
+    List<QueryOuterClass.ColumnSpec> clusteringKeys = table.getClusteringKeyColumnsList();
+    Optional<QueryOuterClass.ColumnSpec> clusteringKey = Optional.empty();
+    if (CollectionUtils.isNotEmpty(clusteringKeys)) {
+      assert clusteringKeys.size() == 1;
+      clusteringKey = Optional.of(clusteringKeys.get(0));
+    }
+    // TODO: support legacy KeyConditions parameter
+    if (StringUtils.isEmpty(queryRequest.getKeyConditionExpression())) {
+      throw new IllegalArgumentException("Must provide a key condition expression");
+    }
+    QueryOuterClass.Query query =
+        constructByKeyConditionExpression(queryRequest, partitionKey, clusteringKey);
+
+    // TODO: support FilterExpression (https://github.com/li-boxuan/stargate/issues/16)
+
+    // TODO: support ProjectionExpression which retrieves a subset of row
+    QueryOuterClass.Response response = bridge.executeQuery(query);
+    List<Map<String, Object>> resultRows = convertRows(response.getResultSet());
+    QueryResult result = new QueryResult();
+    if (!resultRows.isEmpty()) {
+      result.withItems(
+          resultRows.stream()
+              .map(
+                  r ->
+                      r.entrySet().stream()
+                          .collect(
+                              Collectors.toMap(
+                                  Map.Entry::getKey,
+                                  entry -> DataMapper.toDynamo(entry.getValue()))))
+              .collect(Collectors.toList()));
+    }
+    return result;
+  }
+
+  /**
+   * Construct the query from KeyConditionExpression.
+   *
+   * <p>A KeyConditionExpression must have an equality check for partition key, and optionally a
+   * comparison check for clustering key (a.k.a. sort key). We use different regular expressions to
+   * capture all cases.
+   *
+   * <p>See more at
+   * https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Query.html#DDB-Query-request-KeyConditionExpression
+   *
+   * @param queryRequest
+   * @param partitionKey
+   * @param clusteringKey
+   * @return
+   */
+  private QueryOuterClass.Query constructByKeyConditionExpression(
+      QueryRequest queryRequest,
+      QueryOuterClass.ColumnSpec partitionKey,
+      Optional<QueryOuterClass.ColumnSpec> clusteringKey) {
+    final String keyConditionExpression = queryRequest.getKeyConditionExpression();
+    Map<String, String> expressionAttributeNames = queryRequest.getExpressionAttributeNames();
+    Map<String, AttributeValue> expressionAttributeValues =
+        queryRequest.getExpressionAttributeValues();
+
+    Matcher equalityMatcher = EQUALITY_PATTERN.matcher(keyConditionExpression);
+    if (equalityMatcher.find()) {
+      assert equalityMatcher.groupCount() == 2;
+      AttributeValue partitionKeyValue =
+          retrievePartitionKeyValue(
+              equalityMatcher.group(1),
+              partitionKey,
+              equalityMatcher.group(2),
+              expressionAttributeNames,
+              expressionAttributeValues);
+      return new QueryBuilder()
+          .select()
+          .from(KEYSPACE_NAME, queryRequest.getTableName())
+          .where(partitionKey.getName(), Predicate.EQ, DataMapper.fromDynamo(partitionKeyValue))
+          .build();
+    }
+
+    Matcher opComparisonMatcher = OP_COMPARISON_PATTERN.matcher(keyConditionExpression);
+    if (opComparisonMatcher.find()) {
+      assert opComparisonMatcher.groupCount() == 5;
+      AttributeValue partitionKeyValue =
+          retrievePartitionKeyValue(
+              opComparisonMatcher.group(1),
+              partitionKey,
+              opComparisonMatcher.group(2),
+              expressionAttributeNames,
+              expressionAttributeValues);
+
+      String sortKeyName = getKeyName(opComparisonMatcher.group(3), expressionAttributeNames);
+      String sortKeyCompOp = opComparisonMatcher.group(4);
+      Predicate predicate = operatorConverter.get(sortKeyCompOp);
+      if (predicate == null) {
+        throw new IllegalArgumentException(sortKeyCompOp + " is not a supported operator");
+      }
+      checkSortKey(sortKeyName, clusteringKey);
+      AttributeValue sortKeyValue =
+          getExpressionAttributeValue(expressionAttributeValues, opComparisonMatcher.group(5));
+      return new QueryBuilder()
+          .select()
+          .from(KEYSPACE_NAME, queryRequest.getTableName())
+          .where(partitionKey.getName(), Predicate.EQ, DataMapper.fromDynamo(partitionKeyValue))
+          .where(sortKeyName, predicate, DataMapper.fromDynamo(sortKeyValue))
+          .build();
+    }
+
+    Matcher betweenMatcher = BETWEEN_PATTERN.matcher(keyConditionExpression);
+    if (betweenMatcher.find()) {
+      assert betweenMatcher.groupCount() == 5;
+      AttributeValue partitionKeyValue =
+          retrievePartitionKeyValue(
+              betweenMatcher.group(1),
+              partitionKey,
+              betweenMatcher.group(2),
+              expressionAttributeNames,
+              expressionAttributeValues);
+
+      String sortKeyName = getKeyName(betweenMatcher.group(3), expressionAttributeNames);
+      checkSortKey(sortKeyName, clusteringKey);
+      AttributeValue lowerBoundValue =
+          getExpressionAttributeValue(expressionAttributeValues, betweenMatcher.group(4));
+      AttributeValue higherBoundValue =
+          getExpressionAttributeValue(expressionAttributeValues, betweenMatcher.group(5));
+      return new QueryBuilder()
+          .select()
+          .from(KEYSPACE_NAME, queryRequest.getTableName())
+          .where(partitionKey.getName(), Predicate.EQ, DataMapper.fromDynamo(partitionKeyValue))
+          .where(sortKeyName, Predicate.GTE, DataMapper.fromDynamo(lowerBoundValue))
+          .where(sortKeyName, Predicate.LTE, DataMapper.fromDynamo(higherBoundValue))
+          .build();
+    }
+
+    Matcher beginWithMatcher = BEGIN_WITH_PATTERN.matcher(keyConditionExpression);
+    if (beginWithMatcher.find()) {
+      // TODO: address this
+      throw new IllegalArgumentException("Cassandra does not support begin_with query");
+    }
+
+    throw new IllegalArgumentException(keyConditionExpression + " is not a valid expression");
+  }
+
+  /**
+   * Given a raw key name in expression, retrieve its real key name
+   *
+   * <p>A raw key name might be a key name or a key placeholder. A placeholder starts with a '#'
+   * pound sign, whose actual value needs to be retrieved from attributeNames.
+   *
+   * <p>See more at
+   * https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.ExpressionAttributeNames.html
+   *
+   * @param rawKeyName
+   * @param attributeNames
+   * @return
+   */
+  private String getKeyName(String rawKeyName, Map<String, String> attributeNames) {
+    if (rawKeyName.charAt(0) == '#') {
+      return attributeNames.get(rawKeyName);
+    } else {
+      return rawKeyName;
+    }
+  }
+
+  private AttributeValue retrievePartitionKeyValue(
+      String rawKeyName,
+      QueryOuterClass.ColumnSpec partitionKey,
+      String partitionKeyValueMarker,
+      Map<String, String> expressionAttributeNames,
+      Map<String, AttributeValue> expressionAttributeValues) {
+    String partitionKeyName = getKeyName(rawKeyName, expressionAttributeNames);
+    checkPartitionKey(partitionKeyName, partitionKey);
+    return getExpressionAttributeValue(expressionAttributeValues, partitionKeyValueMarker);
+  }
+
+  private void checkPartitionKey(String partitionKeyName, QueryOuterClass.ColumnSpec partitionKey) {
+    if (!Objects.equals(partitionKeyName, partitionKey.getName())) {
+      throw new IllegalArgumentException(
+          partitionKeyName + " does not match partition key name: " + partitionKey.getName());
+    }
+  }
+
+  private void checkSortKey(String sortKeyName, Optional<QueryOuterClass.ColumnSpec> sortKey) {
+    if (!sortKey.isPresent()) {
+      throw new IllegalArgumentException("Sort key does not exist");
+    }
+    if (!Objects.equals(sortKeyName, sortKey.get().getName())) {
+      throw new IllegalArgumentException(
+          sortKeyName + " does not match sort key name: " + sortKey.get().getName());
+    }
+  }
+}

--- a/sgv2-dynamo-api/src/main/java/io/stargate/sgv2/dynamosvc/impl/DynamoServiceServer.java
+++ b/sgv2-dynamo-api/src/main/java/io/stargate/sgv2/dynamosvc/impl/DynamoServiceServer.java
@@ -36,6 +36,7 @@ import io.stargate.sgv2.common.grpc.StargateBridgeClientFactory;
 import io.stargate.sgv2.common.http.CreateStargateBridgeClientFilter;
 import io.stargate.sgv2.common.http.StargateBridgeClientJerseyFactory;
 import io.stargate.sgv2.dynamosvc.dynamo.ItemProxy;
+import io.stargate.sgv2.dynamosvc.dynamo.QueryProxy;
 import io.stargate.sgv2.dynamosvc.dynamo.TableProxy;
 import io.stargate.sgv2.dynamosvc.models.DynamoServiceError;
 import io.stargate.sgv2.dynamosvc.resources.DynamoResource;
@@ -139,7 +140,9 @@ public class DynamoServiceServer extends Application<DynamoServiceServerConfigur
     environment.jersey().register(MetricsResource.class);
 
     // Main data endpoints
-    environment.jersey().register(new DynamoResource(new TableProxy(), new ItemProxy()));
+    environment
+        .jersey()
+        .register(new DynamoResource(new TableProxy(), new ItemProxy(), new QueryProxy()));
 
     // Swagger endpoints
     environment.jersey().register(SwaggerSerializers.class);

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -91,12 +91,12 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-dynamodb</artifactId>
-      <version>1.11.477</version>
+      <version>1.12.190</version>
     </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>DynamoDBLocal</artifactId>
-      <version>1.11.477</version>
+      <version>1.15.0</version>
       <exclusions>
         <exclusion>
           <groupId>com.google.guava</groupId>

--- a/testing/src/main/java/io/stargate/it/http/dynamo/DynamoApiQueryTest.java
+++ b/testing/src/main/java/io/stargate/it/http/dynamo/DynamoApiQueryTest.java
@@ -1,0 +1,261 @@
+package io.stargate.it.http.dynamo;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.amazonaws.services.dynamodbv2.document.*;
+import com.amazonaws.services.dynamodbv2.document.spec.QuerySpec;
+import com.amazonaws.services.dynamodbv2.document.utils.NameMap;
+import com.amazonaws.services.dynamodbv2.document.utils.ValueMap;
+import com.amazonaws.services.dynamodbv2.model.*;
+import io.stargate.it.driver.CqlSessionExtension;
+import io.stargate.it.driver.CqlSessionSpec;
+import io.stargate.it.http.ApiServiceExtension;
+import io.stargate.it.http.ApiServiceSpec;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+import net.jcip.annotations.NotThreadSafe;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@NotThreadSafe
+@ExtendWith(CqlSessionExtension.class)
+@CqlSessionSpec()
+@ExtendWith(ApiServiceExtension.class)
+@ApiServiceSpec(parametersCustomizer = "buildApiServiceParameters")
+public class DynamoApiQueryTest extends BaseDynamoApiTest {
+  private String tableName = "normal_table";
+  private String tableName2 = "table_with_reserved_keyword";
+  private Table proxyTable, awsTable;
+  private Table proxyTable2, awsTable2;
+
+  @BeforeEach
+  public void setUpTable() {
+    createTable();
+    proxyTable = new DynamoDB(proxyClient).getTable(tableName);
+    awsTable = new DynamoDB(awsClient).getTable(tableName);
+    for (Item item : getItems()) {
+      proxyTable.putItem(item);
+      awsTable.putItem(item);
+    }
+
+    proxyTable2 = new DynamoDB(proxyClient).getTable(tableName2);
+    awsTable2 = new DynamoDB(awsClient).getTable(tableName2);
+    for (Item item : getItemsWithReservedWord()) {
+      proxyTable2.putItem(item);
+      awsTable2.putItem(item);
+    }
+  }
+
+  @AfterEach
+  public void deleteTable() {
+    awsClient.deleteTable(tableName);
+    proxyClient.deleteTable(tableName);
+    awsClient.deleteTable(tableName2);
+    proxyClient.deleteTable(tableName2);
+  }
+
+  /**
+   * Test keyConditionExpression with the following format:<br>
+   * partitionKeyName = :partitionkeyval
+   */
+  @Test
+  public void testBasicPartitionKeyExpressionQuery() {
+    // match a single result
+    QuerySpec query =
+        new QuerySpec()
+            .withKeyConditionExpression("Username = :name")
+            .withValueMap(new ValueMap().withString(":name", "bob"));
+    assertEquals(collectResults(awsTable.query(query)), collectResults(proxyTable.query(query)));
+
+    // match multiple results
+    query =
+        new QuerySpec()
+            .withKeyConditionExpression("Username = :v_name")
+            .withValueMap(new ValueMap().withString(":v_name", "alice"));
+    Set<Item> results = collectResults(proxyTable.query(query));
+    assertEquals(3, results.size());
+    assertTrue(getItems().containsAll(results));
+    assertEquals(collectResults(awsTable.query(query)), results);
+  }
+
+  /**
+   * Test KeyConditionExpression with the following format:<br>
+   * partitionKeyName = :partitionkeyval AND sortKeyName OP :sortkeyval<br>
+   * where OP can be "=", ">", "<", ">=", or "<="
+   */
+  @Test
+  public void testSortKeyOperatorComparisonExpressionQuery() {
+    // larger than operator, one result
+    QuerySpec query =
+        new QuerySpec()
+            .withKeyConditionExpression("Username = :name and Birthday > :bday")
+            .withValueMap(new ValueMap().withString(":name", "bob").withNumber(":bday", 19991231));
+    assertEquals(collectResults(awsTable.query(query)), collectResults(proxyTable.query(query)));
+    assertEquals(1, collectResults(proxyTable.query(query)).size());
+
+    // smaller than operator, two results
+    query =
+        new QuerySpec()
+            .withKeyConditionExpression("Username = :v_name AND Birthday < :v_day")
+            .withValueMap(
+                new ValueMap().withString(":v_name", "alice").withNumber(":v_day", 20000102));
+    assertEquals(collectResults(awsTable.query(query)), collectResults(proxyTable.query(query)));
+    assertEquals(2, collectResults(proxyTable.query(query)).size());
+
+    // larger than or equal to operator, three results
+    query =
+        new QuerySpec()
+            .withKeyConditionExpression("Username = :name AND Birthday >= :bday")
+            .withValueMap(
+                new ValueMap().withString(":name", "alice").withNumber(":bday", 19801231));
+    assertEquals(collectResults(awsTable.query(query)), collectResults(proxyTable.query(query)));
+    assertEquals(3, collectResults(proxyTable.query(query)).size());
+
+    // smaller than or equal to operator, one result
+    query =
+        new QuerySpec()
+            .withKeyConditionExpression("Username = :name AND Birthday <= :bday")
+            .withValueMap(new ValueMap().withString(":name", "bob").withNumber(":bday", 20000101));
+    assertEquals(collectResults(awsTable.query(query)), collectResults(proxyTable.query(query)));
+    assertEquals(1, collectResults(proxyTable.query(query)).size());
+
+    // equivalence operator, one result
+    query =
+        new QuerySpec()
+            .withKeyConditionExpression("Username = :name AND Birthday = :bday")
+            .withValueMap(new ValueMap().withString(":name", "bob").withNumber(":bday", 20000101));
+    assertEquals(collectResults(awsTable.query(query)), collectResults(proxyTable.query(query)));
+    assertEquals(1, collectResults(proxyTable.query(query)).size());
+  }
+
+  /**
+   * Test KeyConditionExpression with the following format:<br>
+   * partitionKeyName = :partitionkeyval AND sortKeyName BETWEEN :sortkeyval1 AND :sortkeyval2
+   */
+  @Test
+  public void testSortKeyBetweenComparisonExpressionQuery() {
+    QuerySpec query =
+        new QuerySpec()
+            .withKeyConditionExpression("Username = :name AND Birthday between :lower AND :upper")
+            .withValueMap(
+                new ValueMap()
+                    .withString(":name", "alice")
+                    .withNumber(":lower", 20000101)
+                    .withNumber(":upper", 20000101));
+    assertEquals(collectResults(awsTable.query(query)), collectResults(proxyTable.query(query)));
+    assertEquals(1, collectResults(proxyTable.query(query)).size());
+
+    query =
+        new QuerySpec()
+            .withKeyConditionExpression("Username = :name AND Birthday BETWEEN :lower AND :upper")
+            .withValueMap(
+                new ValueMap()
+                    .withString(":name", "alice")
+                    .withNumber(":lower", 20000101)
+                    .withNumber(":upper", 20010101));
+    assertEquals(collectResults(awsTable.query(query)), collectResults(proxyTable.query(query)));
+    assertEquals(2, collectResults(proxyTable.query(query)).size());
+  }
+
+  /**
+   * Test the case where a key is a reserved keyword in DynamoDB, in which case user shall use a
+   * placeholder (starting with a hashtag #) to represent the name
+   */
+  @Test
+  public void testReservedKeywordExpressionQuery() {
+    QuerySpec query =
+        new QuerySpec()
+            .withKeyConditionExpression("#N = :name AND #D BETWEEN :lower and :upper")
+            .withNameMap(new NameMap().with("#N", "Name").with("#D", "Data"))
+            .withValueMap(
+                new ValueMap()
+                    .withString(":name", "alice")
+                    .withString(":lower", "San Antonio")
+                    .withString(":upper", "San Jose"));
+    assertEquals(collectResults(awsTable2.query(query)), collectResults(proxyTable2.query(query)));
+    assertEquals(2, collectResults(proxyTable2.query(query)).size());
+
+    query
+        .withKeyConditionExpression("#N = :name AND #D <= :upper")
+        .withValueMap(new ValueMap().withString(":name", "alice").withString(":upper", "San Jose"));
+    assertEquals(collectResults(awsTable2.query(query)), collectResults(proxyTable2.query(query)));
+
+    query
+        .withKeyConditionExpression("#N = :name AnD #D > :lower")
+        .withValueMap(
+            new ValueMap().withString(":name", "alice").withString(":lower", "San Antonio"));
+    assertEquals(collectResults(awsTable2.query(query)), collectResults(proxyTable2.query(query)));
+  }
+
+  private Set<Item> collectResults(ItemCollection<QueryOutcome> outcomes) {
+    return StreamSupport.stream(outcomes.spliterator(), false).collect(Collectors.toSet());
+  }
+
+  private Set<Item> getItems() {
+    Set<Item> items = new HashSet<>();
+    items.add(
+        new Item()
+            .withPrimaryKey("Username", "alice", "Birthday", 20000101)
+            .withString("Sex", "F"));
+    items.add(
+        new Item()
+            .withPrimaryKey("Username", "alice", "Birthday", 19801231)
+            .withString("Sex", "F"));
+    items.add(
+        new Item()
+            .withPrimaryKey("Username", "alice", "Birthday", 20000304)
+            .withString("Sex", "F"));
+    items.add(
+        new Item().withPrimaryKey("Username", "bob", "Birthday", 20000101).withString("Sex", "M"));
+    return items;
+  }
+
+  private Set<Item> getItemsWithReservedWord() {
+    // "Name" is a reserved keyword
+    Set<Item> items = new HashSet<>();
+    items.add(new Item().withPrimaryKey("Name", "alice", "Data", "San Diego"));
+    items.add(new Item().withPrimaryKey("Name", "alice", "Data", "San Francisco"));
+    items.add(new Item().withPrimaryKey("Name", "alice", "Data", "New York"));
+    items.add(new Item().withPrimaryKey("Name", "bob", "Data", "New York"));
+    return items;
+  }
+
+  private void createTable() {
+    CreateTableRequest req =
+        new CreateTableRequest()
+            .withTableName(tableName)
+            .withProvisionedThroughput(
+                new ProvisionedThroughput()
+                    .withReadCapacityUnits(100L)
+                    .withWriteCapacityUnits(100L))
+            .withKeySchema(
+                new KeySchemaElement("Username", KeyType.HASH),
+                new KeySchemaElement("Birthday", KeyType.RANGE))
+            .withAttributeDefinitions(
+                new AttributeDefinition("Username", ScalarAttributeType.S),
+                new AttributeDefinition("Birthday", ScalarAttributeType.N));
+    proxyClient.createTable(req);
+    awsClient.createTable(req);
+
+    CreateTableRequest req2 =
+        new CreateTableRequest()
+            .withTableName(tableName2)
+            .withProvisionedThroughput(
+                new ProvisionedThroughput()
+                    .withReadCapacityUnits(100L)
+                    .withWriteCapacityUnits(100L))
+            .withKeySchema(
+                new KeySchemaElement("Name", KeyType.HASH),
+                new KeySchemaElement("Data", KeyType.RANGE))
+            .withAttributeDefinitions(
+                new AttributeDefinition("Name", ScalarAttributeType.S),
+                new AttributeDefinition("Data", ScalarAttributeType.S));
+    proxyClient.createTable(req2);
+    awsClient.createTable(req2);
+  }
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
1. Add the skeleton for Query API
2. Support [KeyConditionExpression](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Query.html#DDB-Query-request-KeyConditionExpression) (the most important parameter in Query API) 

**What this PR does not address**:
1. Exactly the same error message as DynamoDB
3. Legacy parameters
4. FilterExpression
5. ProjectionExpression
6. Limit
7. Pagination
8. ConsistentRead

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
