### PR TITLE
DynamoDB: Skip null value

### DIFF
--- a/sgv2-dynamo-api/src/main/java/io/stargate/sgv2/dynamosvc/dynamo/ItemProxy.java
+++ b/sgv2-dynamo-api/src/main/java/io/stargate/sgv2/dynamosvc/dynamo/ItemProxy.java
@@ -39,6 +39,7 @@ public class ItemProxy extends Proxy {
       assert resultRows.size() == 1;
       result.setItem(
           resultRows.get(0).entrySet().stream()
+              .filter(entry -> entry.getValue() != null)
               .collect(
                   Collectors.toMap(
                       Map.Entry::getKey, entry -> DataMapper.toDynamo(entry.getValue()))));

--- a/sgv2-dynamo-api/src/main/java/io/stargate/sgv2/dynamosvc/dynamo/QueryProxy.java
+++ b/sgv2-dynamo-api/src/main/java/io/stargate/sgv2/dynamosvc/dynamo/QueryProxy.java
@@ -107,6 +107,7 @@ public class QueryProxy extends Proxy {
               .map(
                   r ->
                       r.entrySet().stream()
+                          .filter(entry -> entry.getValue() != null)
                           .collect(
                               Collectors.toMap(
                                   Map.Entry::getKey,

--- a/testing/src/main/java/io/stargate/it/http/dynamo/DynamoApiItemTest.java
+++ b/testing/src/main/java/io/stargate/it/http/dynamo/DynamoApiItemTest.java
@@ -57,7 +57,8 @@ public class DynamoApiItemTest extends BaseDynamoApiTest {
         new Item()
             .withPrimaryKey("Name", "simpleName2")
             .withNumber("Serial", 20)
-            .withNumber("Price", 0.0));
+            .withNumber("Price", 0.0)
+            .withString("Desc", "dummy text"));
 
     Map<String, Object> dict = new HashMap<>();
     dict.put("integerList", Arrays.asList(0, 1, 2));

--- a/testing/src/main/java/io/stargate/it/http/dynamo/DynamoApiQueryTest.java
+++ b/testing/src/main/java/io/stargate/it/http/dynamo/DynamoApiQueryTest.java
@@ -201,11 +201,13 @@ public class DynamoApiQueryTest extends BaseDynamoApiTest {
     items.add(
         new Item()
             .withPrimaryKey("Username", "alice", "Birthday", 20000101)
-            .withString("Sex", "F"));
+            .withString("Sex", "F")
+            .withNumber("Deposit", 100));
     items.add(
         new Item()
             .withPrimaryKey("Username", "alice", "Birthday", 19801231)
-            .withString("Sex", "F"));
+            .withString("Sex", "F")
+            .withNumber("Deposit", 2000));
     items.add(
         new Item()
             .withPrimaryKey("Username", "alice", "Birthday", 20000304)


### PR DESCRIPTION
This fixes the bug when one or more columns are missing
for a row, NullPointerException will be thrown due to
the null value for those columns.

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
